### PR TITLE
Fix a typo

### DIFF
--- a/_posts/18-09-24-retrospective-defis-eig2.md
+++ b/_posts/18-09-24-retrospective-defis-eig2.md
@@ -69,8 +69,7 @@ mentors, les EIG se transforment en de véritables **médiateurs**.
 
 **Quelques exemples de savoir-faire transmis (non exhaustif) :**
 * formations SQL à la DREES ;
-* montée en compétences des directeurs de Centre régional opérationnel ;
-  de surveillance et de sauvetage sur l'utilisation de données ;
+* montée en compétences des directeurs de Centre régional opérationnel de surveillance et de sauvetage sur l'utilisation de données ;
 * mise en place d'applications de datavisualisations via Shiny ;
 * mise en place de méthodes agiles pour gérer le projet Archifiltre.
 


### PR DESCRIPTION
Un point virgule incongru s'était glissé dans le texte (sans doute à cause d'un linter)