### PR TITLE
Retours de Soizic sur l'article d'évaluation

### DIFF
--- a/_posts/2019-06-16-rapport-evaluation-eig.md
+++ b/_posts/2019-06-16-rapport-evaluation-eig.md
@@ -1,64 +1,65 @@
 ---
 layout: post
-title: Quels sont les impacts du programme Entrepreneurs d'intérêt général ? Présentation du rapport d'impacts des promotions 1 & 2.
+title: Quels sont les impacts du programme Entrepreneurs d'intérêt général ? Présentation du rapport d'analyse des promotions 1 & 2
 author: Guénolé Carré, équipe EIG
 twitter: carreguenole
 description: "Dans le cadre de la démarche de mesure d'impact du programme, nous vous présentons les résultats de l'enquête menée auprès des entrepreneurs d'intérêt général (EIG) et des mentors des deux premières promotions."
 ---
-## Prendre du recul grâce à une démarche d'analyse de la mesure d'impact du programme 
+## Prendre du recul grâce à une démarche d'évaluation du programme en interne
 
-Alors que la troisième promotion EIG bat son plein, l’équipe de coordination du programme mêne en parallèle une [démarche d'analyse de la mesure d'impact que nous vous présentions la semaine dernière](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/06/12/demarche-mesure-impact-eig.html). Le présent article fait suite à la [publication des données du programme, première étape de cette démarche](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/06/12/demarche-mesure-impact-eig.html).
+Alors que la troisième promotion EIG bat son plein, l’équipe de coordination du programme mène en parallèle une [démarche de rétrospective sur le programme que nous vous présentions la semaine dernière](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/06/12/demarche-mesure-impact-eig.html). Le présent article fait suite à la [publication des données du programme, première étape de cette démarche](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/06/12/demarche-mesure-impact-eig.html). Il vise à présenter les résultats de la seconde étape : l'enquête que nous avons menée en interne de mars à juin 2019 pour évaluer les résultats des défis et du programme.
 
-Pour mener ce travail à bien cette démarche d'analyse d'impact, nous nous sommes focalisés sur trois aspects du programme sur lesquels nous souhaitions interroger les EIG et les mentors des deux premières promotions du programme : 
+Pour mener à bien cette démarche d'analyse, nous nous sommes focalisés sur trois aspects du programme sur lesquels nous souhaitions interroger les EIG et les mentors des deux premières promotions : 
 - **la capacité des défis à créer des outils répondant à des besoins du terrain, utilisés et pérennisés après le programme** ;
 - **la capacité des défis à impulser un élan de transformation numérique dans leurs administrations d’accueil, en termes d’open data, d’open source, d’utilisation de méthodes de travail agiles, centrées sur l’utilisateur** ;
 - **le rôle joué par le programme et l’équipe de coordination dans la réussite des projets et les axes d’amélioration et d’évolution possibles**.
 
-Nous avons opté pour une méthodologe simple pour nous permettre de réaliser cette étude d'impact : la diffusion de questionnaires aux EIG et mentors des deux premières promotions du programme.Nous avons également illustré les conclusions de cette enquête avec des cas d’usages de défis ou de méthodes utilisées.
+Le rapport est divisé en trois parties, qui reprennent les axes esquissés ci-dessus.
 
-Ce travail possède toutefois certaines limites comme le fait qu'il n'a pas été réalisé de manière indépendante, que nous n'avons pas pu contacter toutes les parties prenantes du programme, et que cette étude ne peut pas aborder de manière exhaustive toutes les externalités liées au programme. 
+Nous avons opté pour une méthodologe simple : la diffusion de questionnaires quantitatifs et qualitatifs aux EIG et mentors des deux premières promotions du programme. Plus de 50% des EIG et mentors contactés y ont répondu. Nous avons également illustré les conclusions de cette enquête avec des cas d’usages de défis ou de méthodes utilisées.
 
-## **[Vous pouvez télécharger ici le rapport d'impact, sous forme de *working paper*](https://entrepreneur-interet-general.etalab.gouv.fr/docs/ProgrammeEIG-Rapport_devaluation-WorkingPaper.pdf)**.
+Ce travail possède certaines limites, comme le fait que tous les mentors et EIG n'ont pas répondu, que nous n'avons pas pu contacter toutes les parties prenantes du programme, que cette étude ne peut pas aborder de manière exhaustive toutes les externalités liées au programme, et qu'elle a été réalisée en interne et non de manière indépendante. Cependant, il présente des tendances intéressantes sur l'impact des EIG sur la transformation numérique de l'Etat et sur les parcours des EIG dans l'administration.
 
-Nous vous présentons aujourd'hui les **résultats clés** que nous retirons des résultats de l'enquête menée auprès des EIG et des mentors des deux premières promotions.
+### **[Vous pouvez télécharger ici le rapport d'analyse, sous forme de *working paper*](https://entrepreneur-interet-general.etalab.gouv.fr/docs/ProgrammeEIG-Rapport_devaluation-WorkingPaper.pdf)**.
+
+Nous vous en présentons aujourd'hui les **résultats clés**.
 
 ## Quels sont les résutalts principaux de cette enquête ? 
+ 
+* **Les outils créés par les EIG sont par une très large majorité déjà en production ou prévus pour l'être. Plus de 90% des mentors sont satisfaits des réalisations des EIG**. Le programme EIG permet le développement d'outils ensuite utilisés dans les administrations lauréates, capables de répondre aux attentes des agents publics et des usagers. Cela appuie également la notion de [**pérennisation des outils**](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/05/20/session-perennisation-defis-eig-3.html), qui est un enjeu crucial pour le programme, notamment car les outils sont souvent mis en production quelques mois après la fin des défis.
 
-* **Les outils créés par les EIG sont par une très large majorité en production, ou en développement avec une mise en production prévue. Plus de 90% des mentors sont satisfaits des réalisations des EIG**.Le programme EIG permet le développement d'outils ensuite utilisés dans les administrations lauréates, capables de répondre aux attentes des agents publics et des usagers (en fonction de la nature des produits développés). Cela appuye également la notion de [**pérennisation des outils**](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/05/20/session-perennisation-defis-eig-3.html), qui est un enjeu crucial pour le programme.
+* On observe **un partage des rôles entre des EIG capables d’apporter des compétences techniques, un mentor opérationnel** (agent public porteur du projet) **qui transmet des connaissances sur le métier, et un mentor de haut niveau** (agent public haut placé hiérarchiquement) **procurant un appui stratégique**. Cette répartition des tâches apparaît comme primordiale pour la réussite des défis**. 
 
-* On observe **un partage des rôles entre des EIG capables d’apporter des compétences techniques, un mentor opérationnel** (agent public porteur du projet) **qui transmet des connaissances sur le métier, et un mentor de haut niveau** (agent public haut placé hiérarchiquement) **procurant un appui stratégique, apparaît comme primordial à la réussite des défis**. 
+* **Deux tiers des EIG ont réutilisé des logiciels libres existants, et de nombreux jeux de données ont été ouverts dans le cadre des défis** : cela participe de la promotion de l'ouverture, qui est au coeur du programme et des missions d'Etalab. 
 
-* **Deux tiers des EIG ont réutilisé des logiciels libres, et de nombreux jeux de données ont été ouverts dans le cadre des défis** : Cela participe de la promotion de l'ouverture, qui est au coeur du programme. 
-
-* **Près de 95% déclarent être satisfaits de l'environnement de travail offert par les administrations dans le cadre du programme**. En intégrant le programme EIG, les administrations lauréates s'engagent en effet à garantir la mobilité et l'autonomie des EIG (travail hors les murs, facilités pour coopérer entre différentes directions, etc.).
+* **Près de 95% déclarent être satisfaits de l'environnement de travail offert par les administrations dans le cadre du programme**. En intégrant le programme EIG, les administrations lauréates s'engagent en effet à garantir la mobilité et l'autonomie des EIG, ainsi qu'en environnement de travail adapté à des développements techniques (accès à des serveurs de stockage et de calcul, travail hors les murs, facilités pour coopérer entre différentes directions, etc.). 
 
 * **62% des EIG ont organisé des formations au cours de leurs défis, et 83% des mentors ont pu réutiliser ces compétences par la suite**. Les EIG participent ainsi à la montée en compétence des agents publics sur le numérique et d'autres thématiques telles que la gestion de projets agiles.
 
-* **73% des EIG et des mentors indiquent avoir été à l’origine de la création d’outils annexes à la réalisation principale du défi**. Ces outils répondent souvent à des besoins techniques constatés par les EIG sur le terrain au cours du défi.
+* **73% des EIG et des mentors indiquent avoir été à l’origine de la création d’outils annexes à la réalisation principale du défi**. Ces outils répondent souvent à des besoins techniques constatés par les EIG sur le terrain au cours du défi, grâce à leur immersion dans les administrations.
 
-![Capture d'écran qui présente les résultats de l'enquête sur les apports de la présence des EIG au cours des défis](https://entrepreneur-interet-general.etalab.gouv.fr/img/blog/illustration-graphe-rapport-evaluation.png)_Graphique présentant les résultats de l'enquête sur les bénéfices de la présence des EIG au cours des défis_
+![Capture d'écran qui présente les résultats de l'enquête sur les apports de la présence des EIG au cours des défis](https://entrepreneur-interet-general.etalab.gouv.fr/img/blog/illustration-graphe-rapport-evaluation.png)_Graphique présentant les résultats de l'enquête sur les bénéfices de la présence des EIG dans leurs administrations._
 
 * **Les motivations exprimées pour devenir EIG résident principalement dans la capacité à agir pour l’intérêt général, l’autonomie permise par ce statut, la durée du programme et la rémunération**.
 
-* **Les mentors notent pour leurs parts la possibilité de recruter des compétences rares dans leurs services, le financement tiers (qui convainc à prendre le risque de lancer des projets innovants) et le portage du programme par Etalab et la DINSIC qui lui donne une dimension interministérielle**. 
+* **Quant aux mentors, ils mettent en avant la possibilité de recruter des compétences rares dans leurs services, le financement tiers (qui convainc à prendre le risque de lancer des projets innovants) et le portage du programme par Etalab et la DINSIC qui lui donne une dimension interministérielle**. 
 
-* Le **programme d’accompagnement** des défis participe à la dimension apprenante du programme : **Les EIG plébiscitent notamment les sessions d’accompagnement collectives, et le suivi tout au long des 10 mois effectué par [l’équipe de coordination](https://entrepreneur-interet-general.etalab.gouv.fr/accompagnement.html) et les [EIG LINK](https://entrepreneur-interet-general.etalab.gouv.fr/defis/2019/eiglink.html)** ; 
+* Le **programme d’accompagnement** des défis participe à la dimension apprenante du programme : **les EIG plébiscitent notamment les sessions d’accompagnement collectives, et le suivi tout au long des 10 mois effectué par [l’équipe de coordination](https://entrepreneur-interet-general.etalab.gouv.fr/accompagnement.html) et les [EIG LINK](https://entrepreneur-interet-general.etalab.gouv.fr/defis/2019/eiglink.html)** ; 
 
-* **Plus de la moitié (52%) des EIG des deux premières promotions ont fait appel à l’expertise de différents membres de l’équipe d’Etalab** ; 
+* **Plus de la moitié (52%) des EIG des deux premières promotions ont fait appel à l’expertise de différents membres de l’équipe d’Etalab**.
 
-* **La communauté réunie autour du programme est perçue positivement par une majorité d’EIG et de mentors**, qui notent ses apports dans la création d’un esprit de groupe, dans le partage d’expérience et l’entraide.
+* **La communauté réunie autour du programme est considérée comme bénéfique par une majorité d’EIG et de mentors**, qui notent ses apports dans la création d’un esprit de groupe, dans le partage d’expérience et l’entraide.
 
-* **Alors qu’avant le programme EIG, seuls 15% d’entre eux souhaitaient continuer à travailler dans l’administration, ils sont plus de 57% à exprimer cette volonté après leurs défis**, ce qui dénote la capacité du programme a faire évoluer les trajectoires professionnelles
+* **Alors qu’avant le programme EIG, seuls 15% d’entre eux souhaitaient continuer à travailler dans l’administration, ils sont plus de 57% à exprimer cette volonté après leurs défis**, ce qui dénote la capacité du programme a faire évoluer les trajectoires professionnelles.
 
-![Deux hommes et une femme sont assis autour d'une table avec deux ordinateurs. Ils discutent et échangent.](/img/blog/datajust-pac.jpg)_De gauche à droite : Paul-Antoine Chevalier, data scientist à Etalab, avec les deux EIG du défi Datajust, Kim Montalibet et Cédric Malherbe_
+![Deux hommes et une femme sont assis autour d'une table avec deux ordinateurs. Ils discutent et échangent.](/img/blog/datajust-pac.jpg)
 
-Cette enquête a également permis d’identifier des **axes d'amélioration pour le programme d'accompagnement** : une préparation approfondie des administrations avant l’arrivée des EIG, ou encore un travail plus poussé sur la réutilisation des outils produits et des données et codes sources ouverts.
+_Kim Montalibet et Cédric Malherbe, les EIG du défi DataJust, présentent leurs outils à Paul-Antoine Chevalier, data scientist à Etalab, lors du demo day interne organisé en juin 2019._
 
-Par ailleurs, des évolutions sont aujourd’hui à l’étude pour faire grandir et pérenniser le programme EIG :
-* une **réplication de la méthode proposée par le programme EIG à différentes échelles** : le programme EIG explore des potentielles coopérations internationales ou territoriales pour encourager des initiatives similaires, via un travail de documentation (méthode, outils, accompagnement) ;
-* la **mise en place de filières de compétences et par thématiques pour les promotions** : cette logique se dessine par la création d’une promotion spécialisée dans l’expérience utilisateurs (designers d'intérêt général) et pourrait être complétée par des projets spécalisés sur une politique publique donnée, comme l’environnement, l’inclusion ou l’action sociale ;
-* l’**accélération de défis issus des promotions antérieures** pourra être un axe de croissance du programme, afin de diversifier le portfolio de projets portés par le programme EIG diversifierait ;
+Cette enquête a également permis d’identifier des **axes d'amélioration pour le programme d'accompagnement**, tels que le renforcement de la préparation des administrations avant l’arrivée des EIG, et un travail plus poussé sur la réutilisation des outils produits et des données et codes sources ouverts. Des perspectives d'évolution sont également à l'étude pour faire grandir et pérenniser le programme EIG. 
 
-**En conclusion, on peut donc voir que le programme EIG permet le développement d'outils qui répondent aux besoins des administrations, grâce à la coopération entre EIG et mentors et à un environnement de travail adapté. De plus, la présence des EIG participe à la transformation numérique des administrations. Le programme est également attractif, apprenant et ouvert, et prépare des perspectives d'évolution pour faire pérenniser ses apports et son modèle de fonctionnement.**
+**En conclusion, ce rapport nous a permis d'établir que le programme EIG permet le développement d'outils qui répondent aux besoins des administrations, grâce à la coopération entre EIG et mentors et à un environnement de travail adapté. De plus, la présence des EIG participe à la transformation numérique des administrations. Le programme est également attractif, apprenant et ouvert : des perspectives d'évolution sont à l'étude pour pérenniser ses apports et son modèle de fonctionnement.**
 
-**Ce rapport d'analyse sera présenté dans sa version finale à la fin du mois de juin.** **Nous publierons bientôt une étude comparative sur d'autres initiatives de recrutement dans le numérique public** à travers le monde, pour mieux comprendre dans quelle dynamique s'inscrit le programme EIG. Cette étude constituera la troisième étape de notre démarche de mesure d'impact.
+**Ce rapport d'analyse sera présenté dans sa version finale à la fin du mois de juin.** **D'autre part, nous publierons bientôt une étude comparative sur d'autres initiatives de recrutement dans le numérique public** à travers le monde, pour mieux comprendre dans quelle dynamique s'inscrit le programme EIG et de quelles bonnes pratiques il pourrait s'inspirer. Cette étude constituera la troisième étape de notre démarche de mesure d'impact.
+
+_Si vous avez envie d'en savoir plus sur le rapport après l'avoir lu, vous pouvez contacter entrepreneur-interet-general@data.gouv.fr. Nous serons ravis d'en discuter avec vous._

--- a/_posts/2019-06-16-rapport-evaluation-eig.md
+++ b/_posts/2019-06-16-rapport-evaluation-eig.md
@@ -1,30 +1,28 @@
 ---
 layout: post
-title: Quels sont les impacts du programme Entrepreneurs d'intérêt général ? Présentation du rapport d'enquête des promotions 1 & 2
+title: Les EIG transforment-ils vraiment l'administration ? Réponses pour les promotions 1 & 2.
 author: Guénolé Carré, équipe EIG
 twitter: carreguenole
-description: "Dans le cadre de la démarche de la démarche d'évaluation du programme, nous vous présentons les résultats de l'enquête menée auprès des entrepreneurs d'intérêt général (EIG) et des mentors des deux premières promotions."
+description: "L'équipe de coordination du programme EIG a mené de la démarche d'évaluation du programme, nous vous présentons les résultats de l'enquête menée auprès des entrepreneurs d'intérêt général (EIG) et des mentors des deux premières promotions."
 ---
-## Prendre du recul grâce à une démarche d'évaluation du programme en interne
+## Prendre du recul sur le programme grâce à une rétrospective
 
-Alors que la troisième promotion EIG bat son plein, l’équipe de coordination du programme mène en parallèle une [démarche de rétrospective sur le programme que nous vous présentions la semaine dernière](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/06/12/demarche-mesure-impact-eig.html). Le présent article fait suite à la [publication des données du programme, première étape de cette démarche](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/05/09/chiffres-eig). Il vise à présenter les résultats de la seconde étape : l'enquête que nous avons menée en interne de mars à juin 2019 pour évaluer les résultats des défis et du programme.
+Alors que la troisième promotion EIG bat son plein, l’équipe de coordination du programme mène en parallèle une [démarche d'évaluation sur le programme que nous vous présentions la semaine dernière](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/06/12/demarche-mesure-impact-eig.html). Le présent article fait suite à la [publication en ligne des données du programme](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/05/09/chiffres-eig). Nous vous présentons désormais la seconde étape de cette démarche : l'enquête que nous avons menée en interne de mars à juin 2019 pour évaluer les résultats des défis et du programme.
 
-Pour mener à bien cette démarche d'analyse, nous nous sommes focalisés sur trois aspects du programme sur lesquels nous souhaitions interroger les EIG et les mentors des deux premières promotions : 
+Pour mener à bien cette enquête, nous nous sommes focalisés sur trois aspects du programme sur lesquels nous souhaitions interroger les EIG et les mentors des deux premières promotions :
 - **la capacité des défis à créer des outils répondant à des besoins du terrain, utilisés et pérennisés après le programme** ;
 - **la capacité des défis à impulser un élan de transformation numérique dans leurs administrations d’accueil, en termes d’open data, d’open source, d’utilisation de méthodes de travail agiles, centrées sur l’utilisateur** ;
 - **le rôle joué par le programme et l’équipe de coordination dans la réussite des projets et les axes d’amélioration et d’évolution possibles**.
 
 Le rapport est divisé en trois parties, qui reprennent les axes esquissés ci-dessus.
 
-Nous avons opté pour une méthodologe simple : la diffusion de questionnaires quantitatifs et qualitatifs aux EIG et mentors des deux premières promotions du programme. Plus de 50% des EIG et mentors contactés y ont répondu. Nous avons également illustré les conclusions de cette enquête avec des cas d’usages de défis ou de méthodes utilisées.
+Nous avons opté pour une méthodologie simple : la diffusion de questionnaires quantitatifs et qualitatifs aux EIG et mentors des deux premières promotions du programme. Plus de 50% des EIG et mentors contactés y ont répondu. Nous avons également illustré les conclusions de cette enquête avec des cas d’usages de défis ou de méthodes utilisées.
 
-Ce travail possède certaines limites, comme le fait que tous les mentors et EIG n'ont pas répondu, que nous n'avons pas pu contacter toutes les parties prenantes du programme, que cette étude ne peut pas aborder de manière exhaustive toutes les externalités liées au programme, et qu'elle a été réalisée en interne et non de manière indépendante. Cependant, il présente des tendances intéressantes sur l'action des EIG dans la transformation numérique de l'Etat et sur les parcours des EIG dans l'administration.
+Cette enquête possède certaines limites, comme le fait que nous n'avons pas pu contacter toutes les parties prenantes du programme, que cette étude ne peut pas aborder de manière exhaustive toutes les externalités liées au programme, et qu'elle a été réalisée en interne et non de manière indépendante. Cependant, les résultats présentent des tendances intéressantes sur l'action des EIG dans la transformation numérique de l'Etat et sur les parcours des EIG dans l'administration.
 
 ### **[Vous pouvez télécharger ici le rapport d'analyse, sous forme de *working paper*](https://entrepreneur-interet-general.etalab.gouv.fr/docs/ProgrammeEIG-Rapport_devaluation-WorkingPaper.pdf)**.
 
-Nous vous en présentons aujourd'hui les **résultats clés**.
-
-## Quels sont les résutalts principaux de cette enquête ? 
+## Quels sont les enseignements principaux de cette enquête ? 
  
 * Le programme EIG permet le développement d'outils ensuite utilisés dans les administrations lauréates, capables de répondre aux attentes des agents publics et des usagers.**Les outils créés par les EIG sont par une très large majorité déjà en production ou prévus pour l'être. Plus de 90% des mentors sont satisfaits des réalisations des EIG**.  Cela appuie également la notion de [**pérennisation des outils**](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/05/20/session-perennisation-defis-eig-3.html), qui est un enjeu crucial pour le programme, notamment car les outils sont souvent mis en production quelques mois après la fin des défis.
 
@@ -32,19 +30,19 @@ Nous vous en présentons aujourd'hui les **résultats clés**.
 
 * La promotion de l'ouverture, par la publication des codes sources des outils produits ou l'open data, est au coeur du programme et des missions d'Etalab. **Deux tiers des EIG ont réutilisé des logiciels libres existants, et de nombreux jeux de données ont été ouverts dans le cadre des défis**. 
 
-* En intégrant le programme EIG, les administrations lauréates s'engagent en effet à garantir la mobilité et l'autonomie des EIG, ainsi qu'en environnement de travail adapté à des développements techniques (accès à des serveurs de stockage et de calcul, travail hors les murs, facilités pour coopérer entre différentes directions, etc.)**Près de 95% déclarent être satisfaits de l'environnement de travail offert par les administrations dans le cadre du programme**. . 
+* En intégrant le programme EIG, les administrations lauréates s'engagent en effet à garantir la mobilité et l'autonomie des EIG, ainsi qu'en environnement de travail adapté à des développements techniques (accès à des serveurs de stockage et de calcul, travail hors les murs, facilités pour coopérer entre différentes directions, etc.). **Près de 95% déclarent être satisfaits de l'environnement de travail offert par les administrations dans le cadre du programme**.
 
-* Les EIG participent à la montée en compétence des agents publics sur le numérique et d'autres thématiques telles que la gestion de projets agiles.**62% des EIG ont organisé des formations au cours de leurs défis, et 83% des mentors ont pu réutiliser ces compétences par la suite**. 
+* Les EIG participent à la montée en compétence des agents publics sur le numérique et d'autres thématiques telles que la gestion de projets agiles. **62% des EIG ont organisé des formations au cours de leurs défis, et 83% des mentors ont pu réutiliser ces compétences par la suite**.
 
-* La présence des EIG permet la création d'outils annexes, qui répondent souvent à des besoins techniques constatés par les EIG sur le terrain grâce à leur immersion dans les administrations.**73% des EIG et des mentors indiquent avoir été à l’origine de la création d’outils annexes à la réalisation principale du défi**. 
+* La présence des EIG permet la création d'outils annexes, qui répondent souvent à des besoins techniques constatés par les EIG sur le terrain grâce à leur immersion dans les administrations. **73% des EIG et des mentors indiquent avoir été à l’origine de la création d’outils annexes à la réalisation principale du défi**.
 
 ![Capture d'écran qui présente les résultats de l'enquête sur les apports de la présence des EIG au cours des défis](https://entrepreneur-interet-general.etalab.gouv.fr/img/blog/illustration-graphe-rapport-evaluation.png)_Graphique présentant les résultats de l'enquête sur les bénéfices de la présence des EIG dans leurs administrations._
 
 * **Les motivations exprimées pour devenir EIG résident principalement dans la capacité à agir pour l’intérêt général, l’autonomie permise par ce statut, la durée du programme et la rémunération**.
 
-* **Quant aux mentors, ils mettent en avant la possibilité de recruter des compétences rares dans leurs services, le financement tiers (qui convainc à prendre le risque de lancer des projets innovants) et le portage du programme par Etalab et la DINSIC qui lui donne une dimension interministérielle**. 
+* **Quant aux mentors, ils mettent en avant la possibilité de recruter des compétences rares dans leurs services, le financement tiers (qui convainc à prendre le risque de lancer des projets innovants) et le portage du programme par Etalab et la DINSIC qui lui donne une dimension interministérielle**.
 
-* Le **programme d’accompagnement** des défis participe à la dimension apprenante du programme : **les EIG plébiscitent notamment les sessions d’accompagnement collectives, et le suivi tout au long des 10 mois effectué par [l’équipe de coordination](https://entrepreneur-interet-general.etalab.gouv.fr/accompagnement.html) et les [EIG LINK](https://entrepreneur-interet-general.etalab.gouv.fr/defis/2019/eiglink.html)** ; 
+* Le **programme d’accompagnement** des défis participe à la dimension apprenante du programme : **les EIG plébiscitent notamment les sessions collectives d’accompagnement , et le suivi tout au long des 10 mois** effectué par [l’équipe de coordination](https://entrepreneur-interet-general.etalab.gouv.fr/accompagnement.html) et les [EIG LINK](https://entrepreneur-interet-general.etalab.gouv.fr/defis/2019/eiglink.html).
 
 * **Plus de la moitié (52%) des EIG des deux premières promotions ont fait appel à l’expertise de différents membres de l’équipe d’Etalab**.
 
@@ -52,12 +50,14 @@ Nous vous en présentons aujourd'hui les **résultats clés**.
 
 * **Alors qu’avant le programme EIG, seuls 15% d’entre eux souhaitaient continuer à travailler dans l’administration, ils sont plus de 57% à exprimer cette volonté après leurs défis**, ce qui dénote la capacité du programme a faire évoluer les trajectoires professionnelles.
 
+Vous pouvez retrouver tous les résultats de l'enquête dans le rapport complet, disponible **[ici](https://entrepreneur-interet-general.etalab.gouv.fr/docs/ProgrammeEIG-Rapport_devaluation-WorkingPaper.pdf)**.
+
 ![Deux hommes et une femme sont assis autour d'une table avec deux ordinateurs. Ils discutent et échangent.](/img/blog/datajust-pac.jpg)
 
 _Kim Montalibet et Cédric Malherbe, les EIG du défi DataJust, présentent leurs outils à Paul-Antoine Chevalier, data scientist à Etalab, lors du demo day interne organisé en juin 2019._
 
-Cette enquête a également permis d’identifier des **axes d'amélioration pour le programme d'accompagnement**, tels que le renforcement de la préparation des administrations avant l’arrivée des EIG, et un travail plus poussé sur la réutilisation des outils produits et des données et codes sources ouverts. Des perspectives d'évolution sont également à l'étude pour faire grandir et pérenniser le programme EIG. 
+Cette enquête a également permis d’identifier des **axes d'amélioration pour le programme d'accompagnement**, tels que le renforcement de la préparation des administrations avant l’arrivée des EIG, et un travail plus poussé sur la réutilisation des outils produits et des données et codes sources ouverts. **Des perspectives d'évolution** sont également à l'étude pour faire grandir et pérenniser le programme EIG.
 
-**En conclusion, ce rapport nous a permis d'établir que le programme EIG permet le développement d'outils qui répondent aux besoins des administrations, grâce à la coopération entre EIG et mentors et à un environnement de travail adapté. De plus, la présence des EIG participe à la transformation numérique des administrations. Le programme est également attractif, apprenant et ouvert : des perspectives d'évolution sont à l'étude pour pérenniser ses apports et son modèle de fonctionnement.**
+**En conclusion, cette enquête nous a permis d'établir que le programme EIG permet le développement d'outils qui répondent aux besoins des administrations, grâce à la coopération entre EIG et mentors et à un environnement de travail adapté. De plus, la présence des EIG participe à la transformation numérique des administrations. Le programme est également attractif, apprenant et ouvert : des perspectives d'évolution sont à l'étude pour pérenniser ses apports et son modèle de fonctionnement.**
 
 _Si vous avez envie d'en savoir plus sur le rapport après l'avoir lu, vous pouvez contacter entrepreneur-interet-general@data.gouv.fr. Nous serons ravis d'en discuter avec vous._

--- a/_posts/2019-06-16-rapport-evaluation-eig.md
+++ b/_posts/2019-06-16-rapport-evaluation-eig.md
@@ -1,13 +1,13 @@
 ---
 layout: post
-title: Quels sont les impacts du programme Entrepreneurs d'intérêt général ? Présentation du rapport d'analyse des promotions 1 & 2
+title: Quels sont les impacts du programme Entrepreneurs d'intérêt général ? Présentation du rapport d'enquête des promotions 1 & 2
 author: Guénolé Carré, équipe EIG
 twitter: carreguenole
-description: "Dans le cadre de la démarche de mesure d'impact du programme, nous vous présentons les résultats de l'enquête menée auprès des entrepreneurs d'intérêt général (EIG) et des mentors des deux premières promotions."
+description: "Dans le cadre de la démarche de la démarche d'évaluation du programme, nous vous présentons les résultats de l'enquête menée auprès des entrepreneurs d'intérêt général (EIG) et des mentors des deux premières promotions."
 ---
 ## Prendre du recul grâce à une démarche d'évaluation du programme en interne
 
-Alors que la troisième promotion EIG bat son plein, l’équipe de coordination du programme mène en parallèle une [démarche de rétrospective sur le programme que nous vous présentions la semaine dernière](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/06/12/demarche-mesure-impact-eig.html). Le présent article fait suite à la [publication des données du programme, première étape de cette démarche](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/06/12/demarche-mesure-impact-eig.html). Il vise à présenter les résultats de la seconde étape : l'enquête que nous avons menée en interne de mars à juin 2019 pour évaluer les résultats des défis et du programme.
+Alors que la troisième promotion EIG bat son plein, l’équipe de coordination du programme mène en parallèle une [démarche de rétrospective sur le programme que nous vous présentions la semaine dernière](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/06/12/demarche-mesure-impact-eig.html). Le présent article fait suite à la [publication des données du programme, première étape de cette démarche](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/05/09/chiffres-eig). Il vise à présenter les résultats de la seconde étape : l'enquête que nous avons menée en interne de mars à juin 2019 pour évaluer les résultats des défis et du programme.
 
 Pour mener à bien cette démarche d'analyse, nous nous sommes focalisés sur trois aspects du programme sur lesquels nous souhaitions interroger les EIG et les mentors des deux premières promotions : 
 - **la capacité des défis à créer des outils répondant à des besoins du terrain, utilisés et pérennisés après le programme** ;
@@ -18,7 +18,7 @@ Le rapport est divisé en trois parties, qui reprennent les axes esquissés ci-d
 
 Nous avons opté pour une méthodologe simple : la diffusion de questionnaires quantitatifs et qualitatifs aux EIG et mentors des deux premières promotions du programme. Plus de 50% des EIG et mentors contactés y ont répondu. Nous avons également illustré les conclusions de cette enquête avec des cas d’usages de défis ou de méthodes utilisées.
 
-Ce travail possède certaines limites, comme le fait que tous les mentors et EIG n'ont pas répondu, que nous n'avons pas pu contacter toutes les parties prenantes du programme, que cette étude ne peut pas aborder de manière exhaustive toutes les externalités liées au programme, et qu'elle a été réalisée en interne et non de manière indépendante. Cependant, il présente des tendances intéressantes sur l'impact des EIG sur la transformation numérique de l'Etat et sur les parcours des EIG dans l'administration.
+Ce travail possède certaines limites, comme le fait que tous les mentors et EIG n'ont pas répondu, que nous n'avons pas pu contacter toutes les parties prenantes du programme, que cette étude ne peut pas aborder de manière exhaustive toutes les externalités liées au programme, et qu'elle a été réalisée en interne et non de manière indépendante. Cependant, il présente des tendances intéressantes sur l'action des EIG dans la transformation numérique de l'Etat et sur les parcours des EIG dans l'administration.
 
 ### **[Vous pouvez télécharger ici le rapport d'analyse, sous forme de *working paper*](https://entrepreneur-interet-general.etalab.gouv.fr/docs/ProgrammeEIG-Rapport_devaluation-WorkingPaper.pdf)**.
 
@@ -26,17 +26,17 @@ Nous vous en présentons aujourd'hui les **résultats clés**.
 
 ## Quels sont les résutalts principaux de cette enquête ? 
  
-* **Les outils créés par les EIG sont par une très large majorité déjà en production ou prévus pour l'être. Plus de 90% des mentors sont satisfaits des réalisations des EIG**. Le programme EIG permet le développement d'outils ensuite utilisés dans les administrations lauréates, capables de répondre aux attentes des agents publics et des usagers. Cela appuie également la notion de [**pérennisation des outils**](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/05/20/session-perennisation-defis-eig-3.html), qui est un enjeu crucial pour le programme, notamment car les outils sont souvent mis en production quelques mois après la fin des défis.
+* Le programme EIG permet le développement d'outils ensuite utilisés dans les administrations lauréates, capables de répondre aux attentes des agents publics et des usagers.**Les outils créés par les EIG sont par une très large majorité déjà en production ou prévus pour l'être. Plus de 90% des mentors sont satisfaits des réalisations des EIG**.  Cela appuie également la notion de [**pérennisation des outils**](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/05/20/session-perennisation-defis-eig-3.html), qui est un enjeu crucial pour le programme, notamment car les outils sont souvent mis en production quelques mois après la fin des défis.
 
-* On observe **un partage des rôles entre des EIG capables d’apporter des compétences techniques, un mentor opérationnel** (agent public porteur du projet) **qui transmet des connaissances sur le métier, et un mentor de haut niveau** (agent public haut placé hiérarchiquement) **procurant un appui stratégique**. Cette répartition des tâches apparaît comme primordiale pour la réussite des défis**. 
+* On observe **un partage des rôles entre des EIG capables d’apporter des compétences techniques, un mentor opérationnel** (agent public porteur du projet) **qui transmet des connaissances sur le métier, et un mentor de haut niveau** (agent public haut placé hiérarchiquement) **procurant un appui stratégique**. Cette répartition des tâches apparaît comme primordiale pour la réussite des défis. 
 
-* **Deux tiers des EIG ont réutilisé des logiciels libres existants, et de nombreux jeux de données ont été ouverts dans le cadre des défis** : cela participe de la promotion de l'ouverture, qui est au coeur du programme et des missions d'Etalab. 
+* La promotion de l'ouverture, par la publication des codes sources des outils produits ou l'open data, est au coeur du programme et des missions d'Etalab. **Deux tiers des EIG ont réutilisé des logiciels libres existants, et de nombreux jeux de données ont été ouverts dans le cadre des défis**. 
 
-* **Près de 95% déclarent être satisfaits de l'environnement de travail offert par les administrations dans le cadre du programme**. En intégrant le programme EIG, les administrations lauréates s'engagent en effet à garantir la mobilité et l'autonomie des EIG, ainsi qu'en environnement de travail adapté à des développements techniques (accès à des serveurs de stockage et de calcul, travail hors les murs, facilités pour coopérer entre différentes directions, etc.). 
+* En intégrant le programme EIG, les administrations lauréates s'engagent en effet à garantir la mobilité et l'autonomie des EIG, ainsi qu'en environnement de travail adapté à des développements techniques (accès à des serveurs de stockage et de calcul, travail hors les murs, facilités pour coopérer entre différentes directions, etc.)**Près de 95% déclarent être satisfaits de l'environnement de travail offert par les administrations dans le cadre du programme**. . 
 
-* **62% des EIG ont organisé des formations au cours de leurs défis, et 83% des mentors ont pu réutiliser ces compétences par la suite**. Les EIG participent ainsi à la montée en compétence des agents publics sur le numérique et d'autres thématiques telles que la gestion de projets agiles.
+* Les EIG participent à la montée en compétence des agents publics sur le numérique et d'autres thématiques telles que la gestion de projets agiles.**62% des EIG ont organisé des formations au cours de leurs défis, et 83% des mentors ont pu réutiliser ces compétences par la suite**. 
 
-* **73% des EIG et des mentors indiquent avoir été à l’origine de la création d’outils annexes à la réalisation principale du défi**. Ces outils répondent souvent à des besoins techniques constatés par les EIG sur le terrain au cours du défi, grâce à leur immersion dans les administrations.
+* La présence des EIG permet la création d'outils annexes, qui répondent souvent à des besoins techniques constatés par les EIG sur le terrain grâce à leur immersion dans les administrations.**73% des EIG et des mentors indiquent avoir été à l’origine de la création d’outils annexes à la réalisation principale du défi**. 
 
 ![Capture d'écran qui présente les résultats de l'enquête sur les apports de la présence des EIG au cours des défis](https://entrepreneur-interet-general.etalab.gouv.fr/img/blog/illustration-graphe-rapport-evaluation.png)_Graphique présentant les résultats de l'enquête sur les bénéfices de la présence des EIG dans leurs administrations._
 
@@ -59,7 +59,5 @@ _Kim Montalibet et Cédric Malherbe, les EIG du défi DataJust, présentent leur
 Cette enquête a également permis d’identifier des **axes d'amélioration pour le programme d'accompagnement**, tels que le renforcement de la préparation des administrations avant l’arrivée des EIG, et un travail plus poussé sur la réutilisation des outils produits et des données et codes sources ouverts. Des perspectives d'évolution sont également à l'étude pour faire grandir et pérenniser le programme EIG. 
 
 **En conclusion, ce rapport nous a permis d'établir que le programme EIG permet le développement d'outils qui répondent aux besoins des administrations, grâce à la coopération entre EIG et mentors et à un environnement de travail adapté. De plus, la présence des EIG participe à la transformation numérique des administrations. Le programme est également attractif, apprenant et ouvert : des perspectives d'évolution sont à l'étude pour pérenniser ses apports et son modèle de fonctionnement.**
-
-**Ce rapport d'analyse sera présenté dans sa version finale à la fin du mois de juin.** **D'autre part, nous publierons bientôt une étude comparative sur d'autres initiatives de recrutement dans le numérique public** à travers le monde, pour mieux comprendre dans quelle dynamique s'inscrit le programme EIG et de quelles bonnes pratiques il pourrait s'inspirer. Cette étude constituera la troisième étape de notre démarche de mesure d'impact.
 
 _Si vous avez envie d'en savoir plus sur le rapport après l'avoir lu, vous pouvez contacter entrepreneur-interet-general@data.gouv.fr. Nous serons ravis d'en discuter avec vous._


### PR DESCRIPTION
Hello,
J'ai relu et j'ai essayé de réintégrer certaines des suggestions de Mathilde qui n'avaient pas été prises en compte, notamment : 
- Le terme "rapport d'impact" qu'il avait été suggéré de ne pas utiliser (j'ai tenté des reformulations)
- La partie sur les évolutions que Mathilde suggérait de synthétiser. 

2 dernières remarques et après je pense qu'on est bon :
- Je pense que l'article serait plus fluide si on présentait les conclusions avant les chiffres, et que c'était elles qu'on mettait en gras. Par exemple, "**Le programme EIG a une forte influence sur les trajectoires professionnelles des EIG.** En effet, alors que seuls 15% d'entre eux..." 
- Eviter de trop mettre de gras pour que seules les informations importantes ressortent. 

La relecture par Simon proposée par Mathilde serait également utile. Qu'en pensez-vous ? 