### PR TITLE
Taille réduite contenu articles de blog

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -973,9 +973,6 @@ body.screenshot {
   padding: 50px 40px;
 }
 .modBlogPost.big .info {
-  /* font-size: 0.78571rem; */
-  /* text-transform: uppercase; */
-  letter-spacing: 3px;
   color: #333;
 }
 .modBlogPost.big h3 {
@@ -1039,6 +1036,8 @@ body.screenshot {
 .modBlogPost.no_bg .content {
   padding: 10px 0 10px;
   background: none;
+  max-width: 800px;
+  margin: 0 auto;
 }
 
 .modBlogPost.no_bg.no-media .content {


### PR DESCRIPTION
Suite à la remarque de @bboulesteix, une taille réduite pour les articles de blog sur un écran d'ordinateur.

Démo par exemple https://deploy-preview-225--entrepreneur-interet-general.netlify.com/blog/2019/06/12/demarche-mesure-impact-eig.html