### PR TITLE
Dernières propositions de changement sur l'article évaluation

### DIFF
--- a/_posts/2019-06-26-rapport-evaluation-eig.md
+++ b/_posts/2019-06-26-rapport-evaluation-eig.md
@@ -1,30 +1,30 @@
 ---
 layout: post
-title: Les EIG transforment-ils vraiment l'administration ? Réponses pour les promotions 1 & 2.
+title: Les EIG transforment-ils vraiment l'administration ? Réponses pour les promotions 1 & 2
 author: Guénolé Carré, équipe EIG
 twitter: carreguenole
-description: "L'équipe de coordination du programme EIG a mené de la démarche d'évaluation du programme, nous vous présentons les résultats de l'enquête menée auprès des entrepreneurs d'intérêt général (EIG) et des mentors des deux premières promotions."
+description: "Dans le cadre de la démarche d'évaluation du programme menée par l'équipe de coordination du programme EIG, nous vous présentons les résultats de l'enquête menée auprès des entrepreneurs d'intérêt général (EIG) et des mentors des deux premières promotions."
 ---
 ## Prendre du recul sur le programme grâce à une rétrospective
 
 **Qu'est ce que le programme Entrepreneurs d'intérêt général ?**
 
-Le programme Entrepreneurs d'intérêt général permet d'intégrer pour 10 mois des profils numériques d'exception dans les administrations pour relever des défis d'amélioration du service public à l'aide du numérique et des données. Ces entrepreneurs sont dans cette démarche épaulé par des mentors qui participent à leurs bonnes intégrations au sein des administrations, et forment une promotion pour laquelle un programme d'accompagnement est dédié.
+Le programme Entrepreneurs d'intérêt général permet d'intégrer pour 10 mois des profils numériques d'exception dans les administrations pour relever des défis d'amélioration du service public à l'aide du numérique et des données. Ces entrepreneurs sont dans cette démarche épaulés par des mentors qui participent à leur bonne intégration au sein des administrations, et forment une promotion accompagnée toute l'année par une équipe d'[Etalab](https://www.etalab.gouv.fr/qui-sommes-nous), au sein de la [Direction interministérielle du numérique](https://numerique.gouv.fr/dinsic/).
 
-Alors que la troisième promotion EIG bat son plein, l’équipe de coordination du programme mène en parallèle une [démarche d'évaluation sur le programme que nous vous présentions la semaine dernière](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/06/12/demarche-mesure-impact-eig.html). 
+Alors que la troisième promotion EIG bat son plein, l’équipe de coordination du programme mène une [démarche d'évaluation sur le programme que nous vous présentions la semaine dernière](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/06/12/demarche-mesure-impact-eig.html). 
 
 **Quels sont les objectifs de cette démarche ?**
 
-Après avoir publié les [données du programme en ligne](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/05/09/chiffres-eig), nous souhaitions  poursuivre cette démarche d'évaluation en enquêtant sur trois aspects clés du programme : 
-- **la capacité des défis à créer des outils répondant à des besoins du terrain, utilisés et pérennisés après le programme** ;
-- **la capacité des défis à impulser un élan de transformation numérique dans leurs administrations d’accueil, en matière d’open data, d’open source, d’utilisation de méthodes de travail agiles, centrées sur l’utilisateur** ;
-- **le rôle joué par le programme et l’équipe de coordination dans la réussite des projets et les axes d’amélioration et d’évolution possibles**.
+Après avoir publié les [données du programme en ligne](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/05/09/chiffres-eig), nous souhaitions poursuivre cette démarche d'évaluation en enquêtant sur trois aspects clés du programme : 
+- la capacité des défis à développer **des outils répondant à des besoins du terrain, utilisés et pérennisés** après le programme ;
+- la capacité des EIG à diffuser **une culture du numérique dans leurs administrations d’accueil**, notamment sur l’open data, l’open source, les méthodes de travail agiles, centrées sur l’utilisateur ;
+- le rôle joué par **le programme et l’équipe de coordination** dans la réussite des projets et les axes d’amélioration et d’évolution possibles.
 
-Les EIG sont intégrés pendant 10 mois dans différentes administrations et viennent répondre à des besoins exprimés par celles-ci dans le cadre d'un appel à projet. Nous souhaitions ainsi tester nos hypothèses selon lesquelles leurs présences permettaient la création d'outils et participaient à la prise en compte du numérique comme un élément clé de la transformation des administrations.
+Plus généralement, nous nous demandions : **"les EIG participent-ils vraiment à la transformation numérique et organisationnelle de l'administration ? De quelle manière ?"**. 
 
 **Quelle méthodologie pour mieux comprendre ces trois aspects ?**
 
-Nous avons opté pour une méthodologie simple pour mieux comprendre ces aspects : la diffusion de questionnaires quantitatifs et qualitatifs aux EIG et mentors des deux premières promotions du programme. Plus de 50 % des EIG et mentors contactés y ont répondu. Nous avons également illustré les conclusions de cette enquête avec des cas d’usages de défis ou de méthodes utilisées.
+Nous avons opté pour une méthodologie simple pour mieux comprendre ces aspects : la diffusion de questionnaires quantitatifs et qualitatifs aux EIG et mentors des deux premières promotions du programme. Plus de 50 % des EIG et mentors contactés y ont répondu. Nous avons également illustré les conclusions de cette enquête par des cas d’usages de défis ou de méthodes utilisées.
 
 Cette enquête possède certaines limites, comme le fait que nous n'avons pas pu contacter toutes les parties prenantes du programme, que cette étude ne peut pas aborder de manière exhaustive toutes les externalités liées au programme, et qu'elle a été réalisée en interne et non de manière indépendante.
 Cependant, les résultats présentent des tendances intéressantes sur l'action des EIG dans la transformation numérique de l'État et sur les parcours des EIG dans l'administration.
@@ -33,39 +33,35 @@ Cependant, les résultats présentent des tendances intéressantes sur l'action 
 
 ## Quels sont les enseignements principaux de cette enquête ?
 
-**Le programme EIG permet le développement d'outils ensuite utilisés dans les administrations lauréates, capables de répondre aux attentes des agents publics et des usagers**.
+**Le programme EIG permet des développer des outils qui répondent aux attentes des agents publics et des usagers**.
 
-Les outils créés par les EIG sont par une très large majorité déjà en production ou prévus pour l'être. Plus de 90 % des mentors sont satisfaits des réalisations des EIG. Cela appuie également la notion de [pérennisation des outils](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/05/20/session-perennisation-defis-eig-3.html), qui est un enjeu crucial pour le programme notamment car les outils sont souvent mis en production quelques mois après la fin des défis.
+La majorité des défis arrive à transformer l'essai et à utiliser les 10 mois du programme pour développer des outils pérennisés après le départ des EIG. Ainsi, la grande majorité des outils créés par les EIG ont soit déjà été mis en production, soit vont l'être prochainement. A noter que les outils sont souvent mis en production quelques mois après la fin des défis, ce qui justifie l'accent mis sur [la pérennisation](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/05/20/session-perennisation-defis-eig-3.html) dès le début des promotions. 
 
-**La création d'équipes complémentaires composées d'EIG et de mentors pour répondre à des défis apparait comme bénéfique**.
+Cette réussite peut être expliquée par plusieurs facteurs. D'une part, les réalisations répondent à de vrais besoins : plus de 90% des mentors interrogés estiment que les outils répondent à leurs attentes initiales. D'autre part, cette pérennisation est permise par les rôles complémentaires dans les équipes défis : les EIG apportent des compétences techniques, le mentor opérationnel (agent public porteur du défi) fait le lien avec les métiers et le mentor de haut niveau, haut placé hiérarchiquement intervient à des moments stratégiques et permet de faire connaître les réalisations à un haut niveau de la hiérachie.
 
-On observe aussi une répartition des rôles au sein des défis entre des EIG capables d’apporter des compétences techniques, un mentor opérationnel (agent public porteur du projet) qui transmet des connaissances sur le métier, et un mentor de haut niveau (agent public haut placé hiérarchiquement) procurant un appui stratégique.
+**Au-delà des outils, les échanges qui s'opèrent entre EIG et mentors ont des bénéfices plus larges pour la tranformation numérique de l'administration**.
 
-**Les échanges qui s'opèrent entre EIG et mentors ont des conséquences plus larges sur la tranformation numérique de l'administration**.
-
-Les mentors indiquent avoir déposé leurs projets dans le but d'accueillir des compétences absentes de leurs services pour développer des outils. Or on constate que la présence des EIG dans les administrations participe à bien plus que cela : création d'outils annexes, formations auprès des agents sur des notions techniques ou de gestion de projets, développement de la culture de l'ouverture. En cela, l'intégration des EIG dans les services crée des externalités positives qui participent à la transformation numérique des administrations.
+Les mentors indiquent avoir déposé leur projet dans le but d'accueillir des compétences absentes de leurs services pour développer des outils. Or on constate que la présence des EIG dans les administrations participe à bien plus que cela : création d'outils annexes, formations auprès des agents sur des notions techniques ou de gestion de projets, développement de la culture de l'ouverture ([open data, open source](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/04/12/accompagnement-open-data-open-source.html)). En cela, l'intégration des EIG dans les services crée des externalités positives qui participent à la transformation numérique des administrations.
 
 ![Capture d'écran qui présente les résultats de l'enquête sur les apports de la présence des EIG au cours des défis](https://entrepreneur-interet-general.etalab.gouv.fr/img/blog/illustration-graphe-rapport-evaluation.png)_Graphique présentant les résultats de l'enquête sur les bénéfices de la présence des EIG dans leurs administrations._
 
-**La transformation numérique passe également par la promotion de l'ouverture, par la publication des codes sources des outils produits ou l'*open data*, élément clé du programme et des missions d'Etalab**.
+**L'accompagnement des EIG tout au long de l'année et la création d'une communauté sont des facteurs importants pour la réussite des défis**.
 
-Le programme Entrepreneurs d'intérêt général est l'occasion de porter cet enjeu au sein des administrations. Les résultats de l'enquête indiquent que deux tiers des EIG ont réutilisé des logiciels libres existants. De nombreux jeux de données ont été  ouverts dans le cadre des défis, comme les [bases de données d'accidentologie en mer](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2018/06/11/travailler-avec-des-donnees-d-exception.html) ou encore les [collections du Mobilier National](https://entrepreneur-interet-general.etalab.gouv.fr/blog/2019/06/14/site-mobilier-national-temoignages-utilisateurs.html). De même, plus de la moitié des EIG des deux premières promotions ont fait appel à l’expertise de différents membres de l’équipe d’Etalab sur des questions techniques, liées aux données ou à la géomatique par exemple.
+La dimension de "communauté", essentielle à la réussite des défis. Ainsi, les EIG plébiscitent les sessions collectives d'accompagnement, qui permettent notamment de l'entraide et de l'émulation entre les équipes et la création d'un esprit de groupe, considéré comme essentiel à la réussite des défis. 
 
-**L'accompagnement des Entrepreneurs tout au long de leurs parcours est un facteur important dans la réussite de leurs défis**.
+Par ailleurs, les EIG interrogés plébiscitent le suivi tout au long des 10 mois effectué par [l’équipe de coordination](https://entrepreneur-interet-general.etalab.gouv.fr/accompagnement.html) et les [EIG Link](https://entrepreneur-interet-general.etalab.gouv.fr/defis/2019/eiglink.html). Le positionnement du programme au sein d'Etalab et de la DINSIC est crucial : plus de la moitié des EIG des deux premières promotions ont fait appel à l’expertise technique et juridique de membres de l’équipe d’Etalab, notamment sur les aspects d'ouverture de données, de licences open source, de mutualisation interministérielle ou de mise à disposition de ressources techniques.
 
-Le programme d’accompagnement des défis participe à la dimension de coopération du programme : les EIG plébiscitent notamment les sessions collectives d’accompagnement qui permettent des apprentissages en pair à pair et des échanges entre défis, ainsi que le suivi tout au long des 10 mois effectué par [l’équipe de coordination](https://entrepreneur-interet-general.etalab.gouv.fr/accompagnement.html) et les [EIG LINK](https://entrepreneur-interet-general.etalab.gouv.fr/defis/2019/eiglink.html).
+**Le programme transforme aussi les EIG et leurs trajectoires professionnelles**.
 
-**Devenir EIG est principalement motivé par le fait de travailler pour l'intérêt général, et le programme fait évoluer les trajectoires professionnelles des entrepreneurs**.
-
-Les motivations exprimées pour devenir EIG résident principalement dans la capacité à agir pour l’intérêt général, l’autonomie permise par ce statut, la durée du programme et la rémunération. Leurs passages des EIG au sein des administrations a d'ailleurs des conséquences sur leurs carrières : alors qu’ils n'étaient que 15 % à souhaiter poursuivre leurs trajectoires professionnelles dans l'administration, ils sont plus de 57 % à exprimer cette volonté après leurs défis.
+Les motivations exprimées pour devenir EIG résident principalement dans la capacité à agir pour l’intérêt général, l’autonomie permise par ce statut, la durée du programme et la rémunération. Leurs passages des EIG au sein des administrations a d'ailleurs des conséquences sur leurs projets de carrières : alors qu’ils n'étaient que 15 % à souhaiter poursuivre leurs trajectoires professionnelles dans l'administration, ils sont plus de 57 % à exprimer cette volonté après leurs défis. Aujourd'hui, plus de la moitié des EIG interrogés travaillent d'ailleurs toujours dans l'administration.
 
 ![Deux hommes et une femme sont assis autour d'une table avec deux ordinateurs. Ils discutent et échangent.](/img/blog/datajust-pac.jpg)
 _Kim Montalibet et Cédric Malherbe, les EIG du défi DataJust, présentent leurs outils à Paul-Antoine Chevalier, data scientist à Etalab, lors du demo day interne organisé en juin 2019._
 
 Cette enquête a également permis d’identifier des **axes d'amélioration pour le programme d'accompagnement**, tels que le renforcement de la préparation des administrations avant l’arrivée des EIG, et un travail plus poussé sur la réutilisation des outils produits et des données et codes sources ouverts. **Des perspectives d'évolution** sont également à l'étude pour faire grandir et pérenniser le programme EIG.
 
-**En conclusion, cette enquête nous a permis d'établir que le programme EIG permet le développement d'outils qui répondent aux besoins des administrations, grâce à la coopération entre EIG et mentors et à un environnement de travail adapté. De plus, la présence des EIG participe à la transformation numérique des administrations. Le programme est également attractif et ouvert : des perspectives d'évolution sont à l'étude pour pérenniser ses apports et son modèle de fonctionnement.**
+En conclusion, on peut donc affirmer que les EIG contribuent bien à la transformation numérique de l'administration grâce aux outils qu'ils développent et à la culture qu'ils diffusent, avec le soutien de la communauté EIG. Cependant, et nous ne l'avions pas anticipé : l'administration les transforme aussi. 
 
 Le rapport sera présenté sous sa forme définitive à la fin juin. La démarche d'évaluation se poursuit également, avec la publication prochaine d'une analyse de différentes initiatives de recrutement similaires au programme EIG dans d'autres pays.
 
-_Si vous avez envie d'en savoir plus sur le rapport après l'avoir lu, vous pouvez contacter entrepreneur-interet-general@data.gouv.fr. Nous serons ravis d'en discuter avec vous._
+_Si vous avez envie d'en savoir plus sur [le rapport](https://entrepreneur-interet-general.etalab.gouv.fr/docs/ProgrammeEIG-Rapport_devaluation-WorkingPaper.pdf) après l'avoir lu, vous pouvez contacter entrepreneur-interet-general@data.gouv.fr. Nous serons ravis d'en discuter avec vous._


### PR DESCRIPTION
Hello, j'ai tenté d'ultimes changements à l'article :
- J'ai intégré la partie sur les équipes complémentaires dans la partie "conception d'outils" .
- J'ai beaucoup aimé la partie sur la transformation plus large, qui fait monter le paragraphe en analyse.
- J'ai complètement enlevé la partie "réutilisation de logiciels libres" car en discutant avec Antoine, ça me paraît être un indicateur compliqué à utiliser pour justifier de la culture de l'ouverture : même dans les entreprises où il n'y a pas de culture de l'open source, on réutilise souvent des librairies.
- J'ai repris le conseil de Sophie sur la partie accompagnement et communauté (mais j'ai un peu mergé les 2 dans un paragraphe). 
J'espère que les changements proposés vous conviennent. 
J'attends relecture de Sophie puis on fait relire à Mathilde ?