### PR TITLE
ajout lien vers profils sur les noms dans la page communauté

### DIFF
--- a/communaute.html
+++ b/communaute.html
@@ -36,7 +36,7 @@ section_id: communaute
 			</a>
 		    </div>
 		    <div class='small-6 columns'>
-			<h3>{{personne.title}}</h3>
+			<h3><a href='{{personne.link_to}}'>{{personne.title}}</a></h3>
 			<p style="font-size:80%;">{{personne.profil}}<br/>
 			    {{personne.defi}}
 			    {{ personne.annees | join: ', '}}</p>


### PR DESCRIPTION
- Jusqu'ici, l'accès aux pages personnels est conditionné au clic sur les photos. Cela limite quelques peu le passage fluide de la page communauté aux pages personnels (quid si pas de photos, question d'accessibilité)

- Cette PR permet l'ajout des liens vers les profils de chaque membre de la communauté à partir de la page communauté. Les liens sont sur les noms de chacun, et s'affichent en bleu EIG comme prévu dans le CSS pour les titres h3.

- Cette PR est faite à partir de l'issue recensé ici : https://github.com/entrepreneur-interet-general/site-eig/issues/241

- Le deploy de test est disponible ici : https://deploy-preview-243--entrepreneur-interet-general.netlify.com/communaute.html