### PR TITLE
Ajouter lien vers articles dans la page d'accueil du blog 

### DIFF
--- a/_includes/post_card.html
+++ b/_includes/post_card.html
@@ -7,8 +7,7 @@
   </div>
   {% endif %}
   <div class="card__content">
-    <a href="{{ post.url }}"><h3>{{ post.title }}</h3>
-    </a>
+    <a href="{{ post.url }}"><h3>{{ post.title }}</h3></a>
     <p class='info'>
       Le
       {% assign m = post.date | date: "%-m" %}

--- a/_includes/post_card.html
+++ b/_includes/post_card.html
@@ -7,7 +7,8 @@
   </div>
   {% endif %}
   <div class="card__content">
-    <h3>{{ post.title }}</h3>
+    <a href="{{ post.url }}"><h3>{{ post.title }}</h3>
+    </a>
     <p class='info'>
       Le
       {% assign m = post.date | date: "%-m" %}


### PR DESCRIPTION
Actuellement, seul l'image cliquable permet d'accéder aux articles de blog. Cette PR ajoute un lien via un clic sur le titre de l'article