### PR TITLE
updated polygraphe key figures

### DIFF
--- a/_data/defis.yml
+++ b/_data/defis.yml
@@ -360,10 +360,12 @@
   mentors:
     - "Audrey Istace"
   key_figures:
-    - amount: 30000000
-      description: "avis analysés"
     - amount: 14
       description: "indicateurs calculés"
+    - amount: 1200000
+      description: "professionnels analysés"
+    - amount: 65000000
+      description: "avis récupérés"
 
 "AchaDef":
   image: /img/defis/dig/AchaDef.png


### PR DESCRIPTION
Je n'ai pas tenté, mais est-ce possible d'ajouter des espaces dans les grands nombres pour séparer les puissances de mille?
Exemple: "30 000 000" au lieu de "30000000"