### PR TITLE
Wébinaires et rediffusions

### DIFF
--- a/_data/webinaires_eig4.yml
+++ b/_data/webinaires_eig4.yml
@@ -55,5 +55,5 @@
   theme: Retours d'expérience d'EIG des promotions précédentes
   date: "mardi 26 mai"
   defis: []
-  inscription_url: https://eig4-webinaire6.eventbrite.fr
+  inscription_url: https://eig4-webinaire7.eventbrite.fr
   rediffusion_url:

--- a/_data/webinaires_eig4.yml
+++ b/_data/webinaires_eig4.yml
@@ -1,0 +1,59 @@
+-
+  theme: Écologie et affaires maritimes
+  date: "mardi 12 mai"
+  defis:
+  - "CapQualif"
+  - "France Transition"
+  inscription_url: https://eig4-webinaire1.eventbrite.fr
+  rediffusion_url: https://app.livestorm.co/demarches-simplifiees/webinaire-eig-1
+-
+  theme: Gestion de crise
+  date: "mercredi 13 mai"
+  defis:
+  - "Enki"
+  - "NEOTac"
+  - "Opérations 18"
+  inscription_url: https://eig4-webinaire2.eventbrite.fr
+  rediffusion_url: https://app.livestorm.co/demarches-simplifiees/webinaire-eig-2
+-
+  theme: Énergie et environnement
+  date: "jeudi 14 mai"
+  defis:
+  - "MonitorFish"
+  - "SIANCE"
+  - "EnviNorma"
+  inscription_url: https://eig4-webinaire3.eventbrite.fr
+  rediffusion_url:
+-
+  theme: Santé et justice
+  date: "lundi 18 mai"
+  defis:
+  - "ADEX"
+  - "DataMed"
+  - "LABEL"
+  inscription_url: https://eig4-webinaire4.eventbrite.fr
+  rediffusion_url:
+-
+  theme: Open source, mutualisation d'outils et mémoire de l'administration
+  date: "mardi 19 mai"
+  defis:
+  - "SEDAccord"
+  - "SSP Datalab"
+  - "EIG Link 2020"
+  inscription_url: https://eig4-webinaire5.eventbrite.fr
+  rediffusion_url:
+-
+  theme: Transparence des politiques publiques
+  date: "mercredi 20 mai"
+  defis:
+  - "Atlas Culture"
+  - "Open Collectivités"
+  - "Datalympics"
+  inscription_url: https://eig4-webinaire6.eventbrite.fr
+  rediffusion_url:
+-
+  theme: Retours d'expérience d'EIG des promotions précédentes
+  date: "mardi 26 mai"
+  defis: []
+  inscription_url: https://eig4-webinaire6.eventbrite.fr
+  rediffusion_url:

--- a/_data/webinaires_eig4.yml
+++ b/_data/webinaires_eig4.yml
@@ -23,7 +23,7 @@
   - "SIANCE"
   - "EnviNorma"
   inscription_url: https://eig4-webinaire3.eventbrite.fr
-  rediffusion_url:
+  rediffusion_url: https://app.livestorm.co/demarches-simplifiees/webinaire-eig-3
 -
   theme: Santé et justice
   date: "lundi 18 mai"

--- a/_includes/defi_webinaire.html
+++ b/_includes/defi_webinaire.html
@@ -2,13 +2,13 @@
   {% if webinaire.defis contains include.defi_slug %}
   <h2>Webinaire</h2>
   <p>
-    Ce défi sera présenté lors du webinaire « {{ webinaire.theme}} » du {{ webinaire.date }}. Ce sera l'occasion de poser vos questions aux agents publics qui portent le défi et d'en découvrir plus sur le programme EIG. 
+    Ce défi sera présenté lors du webinaire « {{ webinaire.theme}} » du {{ webinaire.date }}. Ce sera l'occasion de poser vos questions aux agents publics qui portent le défi et d'en découvrir plus sur le programme EIG.
   </p>
   <p>
     Vous pouvez <a href="{{ webinaire.inscription_url }}" title="Inscription au webinaire">vous inscrire au webinaire en ligne</a>{% if webinaire.rediffusion_url %}. Si le webinaire est passé, vous pouvez en regarder la <a href="{{ webinaire.rediffusion_url }}" title="Rediffusion du webinaire">rediffusion en ligne{% endif%}.
   </p>
   <p>
-    Rendez-vous sur la < a href="https://entrepreneur-interet-general.etalab.gouv.fr/candidature-eig.html" title="Présentation de l'appel à candidatures">page de présentation de l'appel à candidatures</a> pour retrouver la liste complète des webinaires. 
+    Rendez-vous sur la <a href="/candidature-eig.html" title="Présentation de l'appel à candidatures">page de présentation de l'appel à candidatures</a> pour retrouver la liste complète des webinaires.
   </p>
   {% endif %}
 {% endfor %}

--- a/_includes/defi_webinaire.html
+++ b/_includes/defi_webinaire.html
@@ -1,11 +1,14 @@
 {% for webinaire in site.data.webinaires_eig4 %}
   {% if webinaire.defis contains include.defi_slug %}
-  <h2>Wébinaire</h2>
+  <h2>Webinaire</h2>
   <p>
-    Vous pouvez participer au wébinaire de présentation de ce défi et du programme pour poser vos questions aux agents publics qui portent le défi. Ce défi sera présenté lors du wébinaire « {{ webinaire.theme}} » du {{ webinaire.date }}.
+    Ce défi sera présenté lors du webinaire « {{ webinaire.theme}} » du {{ webinaire.date }}. Ce sera l'occasion de poser vos questions aux agents publics qui portent le défi et d'en découvrir plus sur le programme EIG. 
   </p>
   <p>
-    Vous pouvez <a href="{{ webinaire.inscription_url }}" title="Inscription au wébinaire">vous inscrire en ligne</a>{% if webinaire.rediffusion_url %} ou regarder la <a href="{{ webinaire.rediffusion_url }}" title="Rediffusion du wébinaire">rediffusion de ce wébinaire{% endif%}.
+    Vous pouvez <a href="{{ webinaire.inscription_url }}" title="Inscription au wébinaire">vous inscrire au webinaire en ligne</a>{% if webinaire.rediffusion_url %}. Si le webinaire est passé, vous pouvez en regarder la <a href="{{ webinaire.rediffusion_url }}" title="Rediffusion du wébinaire">rediffusion en ligne{% endif%}.
+  </p>
+  <p>
+    Rendez-vous sur la < a href="https://entrepreneur-interet-general.etalab.gouv.fr/candidature-eig.html" title="Présentation de l'appel à candidatures">page de présentation de l'appel à candidatures</a> pour retrouver la liste complète des webinaires. 
   </p>
   {% endif %}
 {% endfor %}

--- a/_includes/defi_webinaire.html
+++ b/_includes/defi_webinaire.html
@@ -5,7 +5,7 @@
     Ce défi sera présenté lors du webinaire « {{ webinaire.theme}} » du {{ webinaire.date }}. Ce sera l'occasion de poser vos questions aux agents publics qui portent le défi et d'en découvrir plus sur le programme EIG. 
   </p>
   <p>
-    Vous pouvez <a href="{{ webinaire.inscription_url }}" title="Inscription au wébinaire">vous inscrire au webinaire en ligne</a>{% if webinaire.rediffusion_url %}. Si le webinaire est passé, vous pouvez en regarder la <a href="{{ webinaire.rediffusion_url }}" title="Rediffusion du wébinaire">rediffusion en ligne{% endif%}.
+    Vous pouvez <a href="{{ webinaire.inscription_url }}" title="Inscription au webinaire">vous inscrire au webinaire en ligne</a>{% if webinaire.rediffusion_url %}. Si le webinaire est passé, vous pouvez en regarder la <a href="{{ webinaire.rediffusion_url }}" title="Rediffusion du webinaire">rediffusion en ligne{% endif%}.
   </p>
   <p>
     Rendez-vous sur la < a href="https://entrepreneur-interet-general.etalab.gouv.fr/candidature-eig.html" title="Présentation de l'appel à candidatures">page de présentation de l'appel à candidatures</a> pour retrouver la liste complète des webinaires. 

--- a/_includes/defi_webinaire.html
+++ b/_includes/defi_webinaire.html
@@ -1,0 +1,11 @@
+{% for webinaire in site.data.webinaires_eig4 %}
+  {% if webinaire.defis contains include.defi_slug %}
+  <h2>Wébinaire</h2>
+  <p>
+    Vous pouvez participer au wébinaire de présentation de ce défi et du programme pour poser vos questions aux agents publics qui portent le défi. Ce défi sera présenté lors du wébinaire « {{ webinaire.theme}} » du {{ webinaire.date }}.
+  </p>
+  <p>
+    Vous pouvez <a href="{{ webinaire.inscription_url }}" title="Inscription au wébinaire">vous inscrire en ligne</a>{% if webinaire.rediffusion_url %} ou regarder la <a href="{{ webinaire.rediffusion_url }}" title="Rediffusion du wébinaire">rediffusion de ce wébinaire{% endif%}.
+  </p>
+  {% endif %}
+{% endfor %}

--- a/_includes/webinaires_eig4.html
+++ b/_includes/webinaires_eig4.html
@@ -1,0 +1,14 @@
+<ul>
+  {% for webinaire in site.data.webinaires_eig4 %}
+  <li>
+    {{ webinaire.date | capitalize }} : {{ webinaire.theme }}
+    {% if webinaire.defis.size > 0 %}
+      {% for defi in webinaire.defis %}
+        <a href="{{ site.data.defis[defi].link_to }}" title="Lien vers le défi">{{ site.data.defis[defi].title }}</a>{% if forloop.last != true %},&nbsp;{% endif %}
+      {% endfor %}
+    {% endif %}
+    (<a href="{{ webinaire.inscription_url }}" title="Inscription au wébinaire">🗓 Inscription</a>{% if webinaire.rediffusion_url %}
+      - <a href="{{ webinaire.rediffusion_url }}" title="Rediffusion du wébinaire">🎥 Rediffusion</a>{% endif %})
+  </li>
+  {% endfor %}
+</ul>

--- a/_includes/webinaires_eig4.html
+++ b/_includes/webinaires_eig4.html
@@ -7,8 +7,8 @@
         <a href="{{ site.data.defis[defi].link_to }}" title="Lien vers le défi">{{ site.data.defis[defi].title }}</a>{% if forloop.last != true %},&nbsp;{% endif %}
       {% endfor %}
     {% endif %}
-    <a href="{{ webinaire.inscription_url }}"  class="button tiny red" title="Inscription au wébinaire">🗓 Inscription</a>{% if webinaire.rediffusion_url %}
-      - <a href="{{ webinaire.rediffusion_url }}"  class="button tiny" title="Rediffusion du wébinaire">🎥 Rediffusion</a>{% endif %}
+    (<a href="{{ webinaire.inscription_url }}" title="Inscription au wébinaire">🗓 Inscription</a>{% if webinaire.rediffusion_url %}
+      - <a href="{{ webinaire.rediffusion_url }}" title="Rediffusion du wébinaire">🎥 Rediffusion</a>{% endif %})
   </li>
   {% endfor %}
 </ul>

--- a/_includes/webinaires_eig4.html
+++ b/_includes/webinaires_eig4.html
@@ -7,8 +7,8 @@
         <a href="{{ site.data.defis[defi].link_to }}" title="Lien vers le défi">{{ site.data.defis[defi].title }}</a>{% if forloop.last != true %},&nbsp;{% endif %}
       {% endfor %}
     {% endif %}
-    (<a href="{{ webinaire.inscription_url }}" title="Inscription au wébinaire">🗓 Inscription</a>{% if webinaire.rediffusion_url %}
-      - <a href="{{ webinaire.rediffusion_url }}" title="Rediffusion du wébinaire">🎥 Rediffusion</a>{% endif %})
+    <a href="{{ webinaire.inscription_url }}"  class="button tiny red" title="Inscription au wébinaire">🗓 Inscription</a>{% if webinaire.rediffusion_url %}
+      - <a href="{{ webinaire.rediffusion_url }}"  class="button tiny" title="Rediffusion du wébinaire">🎥 Rediffusion</a>{% endif %}
   </li>
   {% endfor %}
 </ul>

--- a/_layouts/defi.html
+++ b/_layouts/defi.html
@@ -101,6 +101,8 @@ layout: default
       </p>
       {% endif %}
 
+      {% include defi_webinaire.html defi_slug=page.title %}
+
       {% if defi_data.key_figures %}
       <div class="two spacing"></div>
       <div class="row">

--- a/candidature-eig.html
+++ b/candidature-eig.html
@@ -11,28 +11,20 @@ section_id: candidature-eig
       <h3>Qu’est-ce que le programme Entrepreneurs d’Intérêt Général (EIG) ?</h3>
 
       <p>Le programme s’adresse à des spécialistes en développement, design, data science, data engineering et géomatique qui souhaitent améliorer le service public à l’aide du numérique. Chaque année, une promotion de spécialistes intègre des administrations pendant 10 mois, par équipes pluridisciplinaires de 2 ou 3. Ils y travaillent en étroite collaboration avec les agents publics sur des projets spécifiques que l’on appelle « défis ».</p>
-      
-        <p>Les EIG signent un CDD avec leur administration d'accueil, sur la base de 4 000 € net par mois et commencent le 1er septembre 2020.</p>  
+
+        <p>Les EIG signent un CDD avec leur administration d'accueil, sur la base de 4 000 € net par mois et commencent le 1er septembre 2020.</p>
 
       <p><a href="/defis.html" title="Liste des défis">>>> Découvrez les 17 défis et 41 postes proposés pour la promotion EIG 4<<<</a></p>
 
       <h3>Comment préparer ma candidature ?</h3>
 
       <p>Vous pouvez postuler à 3 profils en remplissant <a href="https://www.demarches-simplifiees.fr/commencer/aac-eig4" title="Formulaire de candidature">un formulaire en ligne, jusqu'au 7 juin 2020, 23h</a>.</p>
-      
+
       <p>Avant tout, <b>vérifiez que vous êtes éligible</b> : le programme est ouvert à toute personne qui n'est pas fonctionnaire ou assimilée au moment de sa candidature, et qui n'est pas en études de premier ou deuxième cycle universitaire au moment du début du programme.</p>
 
       <p><b>Inscrivez-vous à nos webinaires</b> de présentation des défis et du programme pour poser vos questions aux agents publics qui portent les défis et à des EIG des promotions précédentes :</p>
 
-      <ul>
-       <li>Mardi 12 mai : <a href="https://eig4-webinaire1.eventbrite.fr">écologie et affaires maritimes (France Transition, CapQualif)</a> ;</li>
-       <li>Mercredi 13 mai : <a href="https://eig4-webinaire2.eventbrite.fr">gestion de crise (Enki, NEOTac, Opérations 18)</a> ;</li>
-       <li>Jeudi 14 mai : <a href="https://eig4-webinaire3.eventbrite.fr">énergie et environnement (MonitorFish, SIANCE, EnviNorma)</a> ;</li>
-       <li>Lundi 18 mai : <a href="https://eig4-webinaire4.eventbrite.fr">santé et justice (ADEX, DataMed, LABEL)</a> ;</li>
-       <li>Mardi 19 mai : <a href="https://eig4-webinaire5.eventbrite.fr">open source, mutualisation d'outils et mémoire de l'administration (SEDAccord, SSP Datalab, EIG Link)</a> ;</li>
-       <li>Mercredi 20 mai : <a href="https://eig4-webinaire6.eventbrite.fr">transparence des politiques publiques (Atlas Culture, Open collectivités, Datalympics)</a> ;</li>
-       <li>Mardi 26 mai : <a href="https://eig4-webinaire7.eventbrite.fr">retours d'expérience d'EIG des promotions précédentes</a>.</li>
-     </ul>
+      {% include webinaires_eig4.html %}
 
      <p>Nous vous invitons également à :</p>
 
@@ -42,13 +34,13 @@ section_id: candidature-eig
        <li>Regarder les <a href="https://www.dailymotion.com/playlist/x6bp3l" title="Vidéos de témoignages">témoignages d’anciens EIG</a> ;</li>
        <li>Parcourir les <a href="/defis.html" title="Défis"> réalisations des précédentes promotions</a>.</li>
      </ul>
-        
+
      <h3>Comment se déroule la sélection ?</h3>
 
       <p>La première étape : <b>postuler</b> en remplissant <a href="https://www.demarches-simplifiees.fr/commencer/aac-eig4" title="Formulaire de candidautre">un formulaire en ligne, avant le 7 juin 2020, 23h</a>.</p>
 
      <p>Si votre candidature est présélectionnée, vous passerez devant <b>un jury de sélection qui se tiendra du 29 juin au 3 juillet inclus</b>.</p>
-      
+
      <p>Être entrepreneur d'intérêt général demande des compétences techniques, mais aussi beaucoup de qualités humaines. Votre candidature sera donc évaluée selon les critères suivants :</p>
 
      <ul>
@@ -60,13 +52,13 @@ section_id: candidature-eig
      </ul>
 
       <p><b>Les lauréates et lauréats seront notifié(e)s d'ici au 12 juillet</b> et intègreront leurs administrations le 1er septembre 2020.</p>
-        
+
       <p><a href="/defis.html" title="Liste des défis">>>> Découvrez les 17 défis et 41 postes proposés pour la promotion EIG 4<<<</a></p>
-      
+
       <h3>Vous voulez vous engager pour le service public, mais le programme EIG n'est pas pour vous ? L'actualité du numérique dans l'administration vous intéresse ?</h3>
-      
+
       <p> Vous pouvez :</p>
-      
+
       <ul>
         <li>Suivre les <a href="https://beta.gouv.fr/recrutement/">offres d'emploi du réseau des incubateurs des Startups d'Etat</a>, qui propose des CDD et des offres en freelance ;</li>
         <li>Suivre le <a href="https://twitter.com/design_gouv">compte Twitter @design_gouv</a> de l'équipe <a href="https://design.numerique.gouv.fr/">Design des services numériques</a> de la direction interministérielle du numérique pour être tenu au courant de leurs actions.</li>

--- a/css/style.css
+++ b/css/style.css
@@ -219,7 +219,7 @@ ul.shortcode-list i {
   letter-spacing: 1px;
   color: #fff;
   background: #1c419b;
-  border: 0px solid #9D1F1D;
+  border: 0;
 }
 
 .button.tiny {
@@ -231,11 +231,9 @@ ul.shortcode-list i {
 }
 
 .button.red {
-  text-transform: uppercase;
   letter-spacing: 1px;
   color: #fff;
   background: #b01818;
-  border: 2px solid #b01818;
 }
 
 .button.red:hover {

--- a/css/style.css
+++ b/css/style.css
@@ -219,7 +219,7 @@ ul.shortcode-list i {
   letter-spacing: 1px;
   color: #fff;
   background: #1c419b;
-  border: 0;
+  border: 0px solid #9D1F1D;
 }
 
 .button.tiny {
@@ -231,9 +231,11 @@ ul.shortcode-list i {
 }
 
 .button.red {
+  text-transform: uppercase;
   letter-spacing: 1px;
   color: #fff;
   background: #b01818;
+  border: 2px solid #b01818;
 }
 
 .button.red:hover {


### PR DESCRIPTION
Affiche les rediffusions des wébinaires si le wébinaire est passé, sur la page de candidature EIG et sur chaque page de défi.

Pour ajouter une rediffusion, il suffit de renseigner le lien de la rediffusion dans le fichier des wébinaires, `_data/webinaires_eig4.yml`.

Vous pouvoir l'interface sur la preview : https://deploy-preview-372--entrepreneur-interet-general.netlify.app/candidature-eig.html (voir page candidature et des pages de défis).

![image](https://user-images.githubusercontent.com/295709/81939786-c8032780-95c4-11ea-9c85-f6c3903a0e14.png)
![image](https://user-images.githubusercontent.com/295709/81939824-d6514380-95c4-11ea-82ae-550f859ec1a8.png)
